### PR TITLE
Compatibility with Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 
 python:
+  - 2.7
   - 3.6
+  - 3.7
 
 install:
   - pip install -r requirements.txt

--- a/test_similar_posts.py
+++ b/test_similar_posts.py
@@ -26,7 +26,7 @@ class PseudoArticle():
             self.date = datetime.datetime(1970, 1, 1)
 
     def __repr__(self):
-        return f'{self.__class__.__name__}({[t.name for t in self.tags]!r})'
+        return '{}({})'.format(self.__class__.__name__, repr([t.name for t in self.tags]))
 
 
 class NoArticlesTestCase(unittest.TestCase):


### PR DESCRIPTION
I dot not have a need for using this plugin under Python 2,
but this would help fixing `pelican-plugins` CI: https://github.com/getpelican/pelican-plugins/issues/1170